### PR TITLE
IOS-14167 Remove base64 encoding for VCR cassettes

### DIFF
--- a/VCRURLConnection/VCRError.m
+++ b/VCRURLConnection/VCRError.m
@@ -46,7 +46,7 @@
 
 + (NSString *)serializedUserInfo:(NSDictionary *)userInfo {
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:userInfo];
-    return [data base64Encoding];
+    return @"Something";
 }
 
 + (NSDictionary *)deserializedUserInfo:(NSString *)string {

--- a/VCRURLConnection/VCRError.m
+++ b/VCRURLConnection/VCRError.m
@@ -46,7 +46,7 @@
 
 + (NSString *)serializedUserInfo:(NSDictionary *)userInfo {
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:userInfo];
-    return [data base64Encoding];
+    return @"something";
 }
 
 + (NSDictionary *)deserializedUserInfo:(NSString *)string {

--- a/VCRURLConnection/VCRError.m
+++ b/VCRURLConnection/VCRError.m
@@ -46,7 +46,7 @@
 
 + (NSString *)serializedUserInfo:(NSDictionary *)userInfo {
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:userInfo];
-    return @"Something";
+    return [data base64Encoding];
 }
 
 + (NSDictionary *)deserializedUserInfo:(NSString *)string {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -99,7 +99,7 @@
 {
     if ([body isKindOfClass:[NSDictionary class]]) {
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
-    } else if ([self isText]) {
+    } else if ([self isText])  {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
     } else if ([body isKindOfClass:[NSString class]]) {
         self.data = [[NSData alloc] initWithBase64Encoding:body];
@@ -107,7 +107,7 @@
 }
 
 - (NSString *)body {
-    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding;]
+    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -99,7 +99,7 @@
 {
     if ([body isKindOfClass:[NSDictionary class]]) {
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
-    } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
+    } else if ([self isText] {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
     } else if ([body isKindOfClass:[NSString class]]) {
         self.data = [[NSData alloc] initWithBase64Encoding:body];

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -101,9 +101,7 @@
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
     } else if ([self isText]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
-    } else if ([body isKindOfClass:[NSString class]]) {
-        self.data = [[NSData alloc] initWithBase64Encoding:body];
-    }
+    } 
 }
 
 - (NSString *)body {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -102,7 +102,7 @@
     } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
     } else if ([body isKindOfClass:[NSString class]]) {
-        self.data = [[NSData alloc] initWithBase64EncodedString:options:];
+        self.data = [[NSData alloc] initWithBase64EncodedString:options];
     }
 }
 
@@ -113,7 +113,7 @@
     if ([self isText]) {
         return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
     } else {
-        return [self.data base64EncodedStringWithOptions:];
+        return [self.data base64EncodedStringWithOptions];
     }
 }
 

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -105,11 +105,14 @@
 }
 
 - (NSString *)body {
-    if ([self isText]) {
-        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
-    } else {
-        return [self.data base64Encoding];
-    }
+    
+    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
+    
+//    if ([self isText]) {
+//
+//    } else {
+//        return [self.data base64Encoding];
+//    }
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -99,7 +99,7 @@
 {
     if ([body isKindOfClass:[NSDictionary class]]) {
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
-    } else if ([self isText])  {
+    } else if ([self isText]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
     } else if ([body isKindOfClass:[NSString class]]) {
         self.data = [[NSData alloc] initWithBase64Encoding:body];
@@ -107,6 +107,7 @@
 }
 
 - (NSString *)body {
+    /* This method seems to be the method that controls the Base64 encoding, which has now been removed */
     return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
 }
 

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -101,6 +101,8 @@
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
     } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
+    } else if ([body isKindOfClass:[NSString class]]) {
+        self.data = [[NSData alloc] initWithBase64EncodedString:options:];
     }
 }
 
@@ -108,11 +110,11 @@
     
     return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
     
-//    if ([self isText]) {
-//
-//    } else {
-//        return [self.data base64Encoding];
-//    }
+    if ([self isText]) {
+        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
+    } else {
+        return [self.data base64EncodedStringWithOptions:];
+    }
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -101,20 +101,22 @@
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
     } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
-    } else if ([body isKindOfClass:[NSString class]]) {
-        self.data = [[NSData alloc] initWithBase64EncodedString:options];
     }
+    
+   /* else if ([body isKindOfClass:[NSString class]]) {
+        self.data = [[NSData alloc] initWithBase64EncodedString:options];
+    } */
 }
 
 - (NSString *)body {
     
     return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
-    
-    if ([self isText]) {
-        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
-    } else {
-        return [self.data base64EncodedStringWithOptions];
-    }
+//
+//    if ([self isText]) {
+//        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
+//    } else {
+//        return [self.data base64EncodedStringWithOptions];
+//    }
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -112,7 +112,7 @@
     if ([self isText]) {
         return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
     } else {
-        return [self.data base64EncodedStringWithOptions];
+        return [self.data base64Encoding];
     }
 }
 

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -109,11 +109,7 @@
 }
 
 - (NSString *)body {
-    if ([self isText]) {
-        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
-    } else {
-        return [self.data base64Encoding];
-    }
+    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -101,15 +101,13 @@
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
     } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
-    }
-    
-   /* else if ([body isKindOfClass:[NSString class]]) {
+    } else if ([body isKindOfClass:[NSString class]]) {
         self.data = [[NSData alloc] initWithBase64EncodedString:options];
-    } */
+    }
 }
 
 - (NSString *)body {
-    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
+    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding;]
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -99,10 +99,8 @@
 {
     if ([body isKindOfClass:[NSDictionary class]]) {
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
-    } else if ([self isText]) {
+    } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
-    } else if ([body isKindOfClass:[NSString class]]) {
-        self.data = [[NSData alloc] initWithBase64Encoding:body];
     }
 }
 

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -109,14 +109,11 @@
 }
 
 - (NSString *)body {
-    
-    return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
-//
-//    if ([self isText]) {
-//        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
-//    } else {
-//        return [self.data base64EncodedStringWithOptions];
-//    }
+    if ([self isText]) {
+        return [[NSString alloc] initWithData:self.data encoding:NSUTF8StringEncoding];
+    } else {
+        return [self.data base64EncodedStringWithOptions];
+    }
 }
 
 - (id)JSON {

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -102,7 +102,7 @@
     } else if ([self isText] || [body isKindOfClass:[NSString class]]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
     } else if ([body isKindOfClass:[NSString class]]) {
-        self.data = [[NSData alloc] initWithBase64EncodedString:options];
+        self.data = [[NSData alloc] initWithBase64Encoding:body];
     }
 }
 

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -99,7 +99,7 @@
 {
     if ([body isKindOfClass:[NSDictionary class]]) {
         self.data = [NSJSONSerialization dataWithJSONObject:body options:0 error:nil];
-    } else if ([self isText] {
+    } else if ([self isText]) {
         self.data = [body dataUsingEncoding:NSUTF8StringEncoding];
     } else if ([body isKindOfClass:[NSString class]]) {
         self.data = [[NSData alloc] initWithBase64Encoding:body];


### PR DESCRIPTION
There was an issue where newly recorded cassettes where being encoded in base64 only on M1 machines. See this JIRA ticket here: https://pelotoncycle.atlassian.net/browse/IOS-14167

This PR removes the mechanism that actually does the encoding and ensures Cassettes no longer get encoded. 

NOTE: if you're currently working on a branch, you may have to run `argon atoms --build-strategies carthage` to get this fix. 