### PR TITLE
GraphQL Fix for VCR

### DIFF
--- a/VCRURLConnection.xcodeproj/project.pbxproj
+++ b/VCRURLConnection.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		27DE8674262FA49500B7814D /* NSMutableURLRequest+VCR.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DE8672262FA49500B7814D /* NSMutableURLRequest+VCR.m */; };
+		27DE8675262FA49500B7814D /* NSMutableURLRequest+VCR.h in Headers */ = {isa = PBXBuildFile; fileRef = 27DE8673262FA49500B7814D /* NSMutableURLRequest+VCR.h */; };
 		9016CEB91DCB007600E30595 /* VCR.m in Sources */ = {isa = PBXBuildFile; fileRef = B3B82897167E9B6800CCEC3C /* VCR.m */; };
 		9016CEBB1DCB007600E30595 /* VCR+NSURLSessionConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = B3DEFB751877157300D3FE16 /* VCR+NSURLSessionConfiguration.m */; };
 		9016CEBE1DCB007600E30595 /* VCRCassette.m in Sources */ = {isa = PBXBuildFile; fileRef = B3B8289A167E9B6800CCEC3C /* VCRCassette.m */; };
@@ -98,6 +100,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		27DE8672262FA49500B7814D /* NSMutableURLRequest+VCR.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+VCR.m"; sourceTree = "<group>"; };
+		27DE8673262FA49500B7814D /* NSMutableURLRequest+VCR.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+VCR.h"; sourceTree = "<group>"; };
 		9016CE9F1DCAFEC500E30595 /* VCRURLConnection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VCRURLConnection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3475BAD167EFFA70044511D /* VCRRecording.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VCRRecording.h; sourceTree = "<group>"; };
 		B3475BAE167EFFA80044511D /* VCRRecording.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VCRRecording.m; sourceTree = "<group>"; };
@@ -226,6 +230,8 @@
 				B359FCE51876411D00FA20E2 /* VCRReplayingURLProtocol.m */,
 				B3B8289F167E9B6800CCEC3C /* VCRRequestKey.h */,
 				B3B828A0167E9B6800CCEC3C /* VCRRequestKey.m */,
+				27DE8673262FA49500B7814D /* NSMutableURLRequest+VCR.h */,
+				27DE8672262FA49500B7814D /* NSMutableURLRequest+VCR.m */,
 			);
 			path = VCRURLConnection;
 			sourceTree = "<group>";
@@ -324,6 +330,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27DE8675262FA49500B7814D /* NSMutableURLRequest+VCR.h in Headers */,
 				B3D88C5E1BDDCC1A0001357A /* VCRURLConnection.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,6 +460,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = B3B8284C167E990F00CCEC3C;
@@ -532,6 +540,7 @@
 				B3D88C561BDDCBBB0001357A /* VCRCassetteManager.m in Sources */,
 				B3D88C571BDDCBBB0001357A /* VCRError.m in Sources */,
 				B3D88C581BDDCBBB0001357A /* VCROrderedMutableDictionary.m in Sources */,
+				27DE8674262FA49500B7814D /* NSMutableURLRequest+VCR.m in Sources */,
 				B3D88C591BDDCBBB0001357A /* VCRRecording.m in Sources */,
 				B3D88C5A1BDDCBBB0001357A /* VCRRecordingURLProtocol.m in Sources */,
 				B3D88C5B1BDDCBBB0001357A /* VCRReplayingURLProtocol.m in Sources */,

--- a/VCRURLConnection/NSMutableURLRequest+VCR.h
+++ b/VCRURLConnection/NSMutableURLRequest+VCR.h
@@ -1,0 +1,21 @@
+//
+//  NSMutableURLRequest+VCR.h
+//  VCRURLConnection
+//
+//  Created by Mike Akers on 4/20/21.
+//
+
+#import <Foundation/Foundation.h>
+
+
+@interface NSURLRequest (CustomHTTPBody)
+/**
+ *   Unfortunately, when sending POST requests (with a body) using NSURLSession,
+ *   by the time the request arrives at OHHTTPStubs, the HTTPBody of the
+ *   NSURLRequest has been reset to nil.
+ *
+ *   You can use this method to retrieve the HTTPBody for testing and use it to
+ *   conditionally stub your requests.
+ */
+- (NSData *)OHHTTPStubs_HTTPBody;
+@end

--- a/VCRURLConnection/NSMutableURLRequest+VCR.m
+++ b/VCRURLConnection/NSMutableURLRequest+VCR.m
@@ -1,0 +1,77 @@
+//
+//  NSMutableURLRequest+VCR.m
+//  VCRURLConnection
+//
+//  Created by Mike Akers on 4/20/21.
+//
+
+#import "NSMutableURLRequest+VCR.h"
+#import "VCRRecordingURLProtocol.h"
+
+//#import "OHHTTPStubsMethodSwizzling.h"
+
+#import <objc/runtime.h>
+
+IMP OHHTTPStubsReplaceMethod(SEL selector,
+                             IMP newImpl,
+                             Class affectedClass,
+                             BOOL isClassMethod)
+{
+    Method origMethod = isClassMethod ? class_getClassMethod(affectedClass, selector) : class_getInstanceMethod(affectedClass, selector);
+    IMP origImpl = method_getImplementation(origMethod);
+    
+    if (!class_addMethod(isClassMethod ? object_getClass(affectedClass) : affectedClass, selector, newImpl, method_getTypeEncoding(origMethod)))
+    {
+        method_setImplementation(origMethod, newImpl);
+    }
+
+    return origImpl;
+}
+
+
+NSString * const OHHTTPStubs_HTTPBodyKey = @"HTTPBody";
+
+@implementation NSURLRequest (CustomHTTPBody)
+
+- (NSData*)OHHTTPStubs_HTTPBody
+{
+    return [NSURLProtocol propertyForKey:OHHTTPStubs_HTTPBodyKey inRequest:self];
+}
+
+@end
+
+typedef void(*OHHHTTPStubsSetterIMP)(id, SEL, id);
+static OHHHTTPStubsSetterIMP orig_setHTTPBody;
+
+static void OHHTTPStubs_setHTTPBody(id self, SEL _cmd, NSData* HTTPBody)
+{
+    // store the http body via NSURLProtocol
+    if (HTTPBody) {
+//        [NSURLProtocol setProperty:HTTPBody forKey:OHHTTPStubs_HTTPBodyKey inRequest:self];
+        [[VCRRecordingURLProtocol foo] setObject:HTTPBody forKey:@"foo"];
+    } else {
+        // unfortunately resetting does not work properly as the NSURLSession also uses this to reset the property
+    }
+
+    orig_setHTTPBody(self, _cmd, HTTPBody);
+}
+
+/**
+ *   Swizzles setHTTPBody: in order to maintain a copy of the http body for later
+ *   reference and calls the original implementation.
+ *
+ *   @warning Should not be used in production, testing only.
+ */
+@interface NSMutableURLRequest (HTTPBodyTesting) @end
+
+@implementation NSMutableURLRequest (HTTPBodyTesting)
+
++ (void)load
+{
+    orig_setHTTPBody = (OHHHTTPStubsSetterIMP)OHHTTPStubsReplaceMethod(@selector(setHTTPBody:),
+                                                                       (IMP)OHHTTPStubs_setHTTPBody,
+                                                                       [NSMutableURLRequest class],
+                                                                       NO);
+}
+
+@end

--- a/VCRURLConnection/VCRRecording.h
+++ b/VCRURLConnection/VCRRecording.h
@@ -33,6 +33,7 @@
 
 @property (nonatomic, strong) NSString *method;
 @property (nonatomic, strong) NSString *URI;
+@property (nonatomic, strong) NSData *requestData;
 @property (nonatomic, strong) NSRegularExpression *URIRegex;
 @property (nonatomic, strong) NSData *data;
 @property (weak, nonatomic, readonly) NSString *body;

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -125,6 +125,10 @@
     } else {
         dictionary[@"uri-regex"] = self.URIRegex.pattern;
     }
+    
+    if (self.requestData) {
+        dictionary[@"requestData"] = [[NSString alloc] initWithData:self.requestData encoding:NSUTF8StringEncoding];
+    }
 
     if (self.headerFields) {
         dictionary[@"headers"] = self.headerFields;

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -56,6 +56,8 @@
             self.headerFields = [NSDictionary dictionary];
         }
         
+        self.requestData = [json[@"requestData"] dataUsingEncoding:NSUTF8StringEncoding];
+        
         NSString *body = json[@"body"];
         [self setBody:body];
         

--- a/VCRURLConnection/VCRRecordingURLProtocol.h
+++ b/VCRURLConnection/VCRRecordingURLProtocol.h
@@ -25,4 +25,6 @@
 
 @interface VCRRecordingURLProtocol : NSURLProtocol
 
+@property (class, readonly) NSMutableDictionary *foo;
+
 @end

--- a/VCRURLConnection/VCRRecordingURLProtocol.m
+++ b/VCRURLConnection/VCRRecordingURLProtocol.m
@@ -54,6 +54,7 @@ static NSString * const VCRIsRecordingRequestKey = @"VCR_recording";
     VCRRecording *recording = [[VCRRecording alloc] init];
     recording.method = request.HTTPMethod;
     recording.URI = [[request URL] absoluteString];
+    recording.requestData = request.HTTPBody;
     self.recording = recording;
     
     NSMutableURLRequest *mutableRequest = [request mutableCopy];

--- a/VCRURLConnection/VCRRecordingURLProtocol.m
+++ b/VCRURLConnection/VCRRecordingURLProtocol.m
@@ -34,6 +34,8 @@ static NSString * const VCRIsRecordingRequestKey = @"VCR_recording";
 @end
 
 @implementation VCRRecordingURLProtocol
+static NSMutableDictionary *_foo = nil;
+
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request {
     BOOL isAlreadyRecordingRequest = [[self propertyForKey:VCRIsRecordingRequestKey inRequest:request] boolValue];
@@ -45,6 +47,14 @@ static NSString * const VCRIsRecordingRequestKey = @"VCR_recording";
     return request;
 }
 
++ (void)load {
+    _foo = [[NSMutableDictionary alloc] init];
+}
+
++ (NSMutableDictionary *)foo {
+    return _foo;
+}
+
 - (id)initWithRequest:(NSURLRequest *)request cachedResponse:(NSCachedURLResponse *)cachedResponse client:(id<NSURLProtocolClient >)client {
     return [super initWithRequest:request cachedResponse:nil client:client];
 }
@@ -54,7 +64,7 @@ static NSString * const VCRIsRecordingRequestKey = @"VCR_recording";
     VCRRecording *recording = [[VCRRecording alloc] init];
     recording.method = request.HTTPMethod;
     recording.URI = [[request URL] absoluteString];
-    recording.requestData = request.HTTPBody;
+    recording.requestData = [_foo objectForKey:@"foo"];//[NSURLProtocol propertyForKey:@"HTTPBody" inRequest: request];
     self.recording = recording;
     
     NSMutableURLRequest *mutableRequest = [request mutableCopy];

--- a/VCRURLConnection/VCRRequestKey.m
+++ b/VCRURLConnection/VCRRequestKey.m
@@ -30,6 +30,7 @@
 
 @property (nonatomic, strong, readwrite) NSString *URI;
 @property (nonatomic, strong, readwrite) NSString *method;
+@property (nonatomic, strong, readwrite) NSData *data;
 
 @end
 
@@ -50,6 +51,7 @@
     if ((self = [super init])) {
         self.URI = recording.URI;
         self.method = [recording.method uppercaseString];
+        self.data = recording.requestData;
     }
     return self;
 }
@@ -58,6 +60,7 @@
     if ((self = [super init])) {
         self.URI = [request.URL absoluteString];
         self.method = [request.HTTPMethod uppercaseString];
+        self.data = request.HTTPBody;
     }
     return self;
 }
@@ -67,11 +70,13 @@
 }
 
 - (BOOL)isEqual:(VCRRequestKey *)key {
-    return [self.method isEqual:key.method] && [self.URI isEqual:key.URI];
+    return [self.method isEqual:key.method]
+        && [self.URI isEqual:key.URI]
+        && (self.data == nil && key.data == nil) || [self.data isEqual:key.data];
 }
 
 - (NSUInteger)hash {
-    return [self.method hash] ^ [self.URI hash];
+    return [self.method hash] ^ [self.URI hash] ^ [self.data hash];
 }
 
 - (id)copyWithZone:(NSZone *)zone {
@@ -79,12 +84,13 @@
     if (key) {
         key.URI = [self.URI copyWithZone:zone];
         key.method = [self.method copyWithZone:zone];
+        key.data = [self.data copyWithZone:zone];
     }
     return key;
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"<VCRRequestKey %@ %@>", self.method, self.URI];
+    return [NSString stringWithFormat:@"<VCRRequestKey %@ %@ %@>", self.method, self.URI, self.data];
 }
 
 @end

--- a/VCRURLConnectionTests/VCRRecordingTests.m
+++ b/VCRURLConnectionTests/VCRRecordingTests.m
@@ -24,6 +24,7 @@
     self.json = @{
         @"method": @"GET",
         @"uri": @"http://foo",
+        @"requestData" : @"quux",
         @"status": @200,
         @"body": @"Foo Bar Baz",
         @"headers": @{ @"X-Foo": @"foo" },
@@ -42,6 +43,8 @@
     VCRRecording *recording = [[VCRRecording alloc] initWithJSON:json];
     
     XCTAssertEqualObjects(recording.URI, [json objectForKey:@"uri"], @"");
+    
+    XCTAssertEqualObjects(recording.requestData, [[json objectForKey:@"requestData"] dataUsingEncoding:NSUTF8StringEncoding], @"");
     
     XCTAssertEqual(recording.statusCode, [[json objectForKey:@"status"] integerValue], @"");
     

--- a/VCRURLConnectionTests/VCRRequestKeyTests.m
+++ b/VCRURLConnectionTests/VCRRequestKeyTests.m
@@ -35,12 +35,14 @@
     NSString *path = @"http://foo/bar";
     
     NSURL *url = [NSURL URLWithString:path];
-    NSURLRequest *request1 = [[NSURLRequest alloc] initWithURL:url];
+    NSMutableURLRequest *request1 = [[NSMutableURLRequest alloc] initWithURL:url];
+    request1.HTTPBody = [@"" dataUsingEncoding:NSUTF8StringEncoding];
     self.key1 = [VCRRequestKey keyForObject:request1];
 
     VCRRecording *recording = [[VCRRecording alloc] init];
     recording.method = @"GET";
     recording.URI = path;
+    recording.requestData = [@"" dataUsingEncoding:NSUTF8StringEncoding];
     self.key2 = [VCRRequestKey keyForObject:recording];
 }
 


### PR DESCRIPTION
This PR includes a hacky workaround that Mike wrote that has been sitting idly for more than a year. I've tested this with the Tags Tests (which is backed by GraphQL) and it seems like it works. Playback is not disrupted and Tags displays on the profile even with the creation of a new tag. 

Just so we don't disrupt the original branch I've branched off his branch just so we can merge this with minimal conflict if further work is needed. 

Out of scope: 
This does not work for TV UI tests afaik. 